### PR TITLE
Remove rootdir requirement

### DIFF
--- a/scripts/ios/didRegisterUserNotificationSettings.js
+++ b/scripts/ios/didRegisterUserNotificationSettings.js
@@ -29,12 +29,8 @@
 
 
 var fs = require('fs'),
-    path = require('path'),
-    rootdir = process.argv[2];
-
-if (!rootdir)
-    return;
-
+    path = require('path');
+	
 module.exports = function (context) {
 
     var cordova_util = context.requireCordovaModule('cordova-lib/src/cordova/util'),


### PR DESCRIPTION
We were getting compile errors due to missing
UIApplicationRegisterUserNotificationSettings when building with Visual
Studio.

It seems like vs-mda-remote calls cordova hooks directly from node.js
and therefore argv has only 2 entries.
